### PR TITLE
TabLayout should use the same theme color

### DIFF
--- a/app/src/main/res/layout/ac_tabs_styled.xml
+++ b/app/src/main/res/layout/ac_tabs_styled.xml
@@ -8,7 +8,7 @@
         style="@style/TabLayoutStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/violet_100" />
+        android:background="@color/petrol_100" />
 
     <android.support.v4.view.ViewPager
         android:id="@+id/viewPager"


### PR DESCRIPTION
TabLayout is currently using `blue_100` but should rather use the `petrol_100` inherited from the Activity primary color:
https://github.com/materialdoc/materialdoc/blob/master/app/src/main/res/values/styles.xml#L71
